### PR TITLE
allow capital variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,8 @@ lint.select = [
   "PLE",  # Pylint error https://github.com/charliermarsh/ruff#error-ple
 ]
 lint.ignore = [
-"D100", "D101", "D104", "D105", "D106", "D107", "D203", "D213", "D413"
+"D100", "D101", "D104", "D105", "D106", "D107", "D203", "D213", "D413",
+"N806" # Allow capital letters in variables
 ] # docstring style
 
 line-length = 120


### PR DESCRIPTION
We will allow the capital letters in the variables to suit the convention in the radar interferometry community.
There are mathematical symbols like Qyy, A, B which are commonly used and understood by the community.