### PR TITLE
Replace print statements with logging in arc_estimation and network

### DIFF
--- a/depsi/arc_estimation.py
+++ b/depsi/arc_estimation.py
@@ -1,5 +1,6 @@
 """arc estimation algorithms."""
 
+import logging
 from typing import Literal
 
 import dask.array as da
@@ -10,6 +11,8 @@ from scipy.optimize import curve_fit
 import depsi.model_definition as md
 import depsi.stats as est
 from depsi.utils import get_distance, wrap_phase
+
+logger = logging.getLogger(__name__)
 
 # Constants
 STOP_HEIGHT = 1e-4  # Stop search step for height [m]
@@ -661,8 +664,8 @@ def arc_estimation_xarray_input(
         "succeeded_arcs": [],
     }
 
-    print(f"idx pnt i: {int(stm_pnt_i['space'].values)}")
-    print(f"idx pnt j: {int(stm_pnt_j['space'].values)}")
+    logger.debug(f"idx pnt i: {int(stm_pnt_i['space'].values)}")
+    logger.debug(f"idx pnt j: {int(stm_pnt_j['space'].values)}")
 
     dates = stm_pnt_i["time"].values
     Btemporal = stm_pnt_i["years_since_first_img"].values
@@ -836,8 +839,8 @@ def arc_estimation_xarray_input(
         )
 
     except (RuntimeError, ValueError) as e:
-        print(f"Optimal parameters not found. Skipping arc {(pnt_i_idx, pnt_j_idx)}")
-        print(f"Encountered error: {e}")
+        logger.warning(f"Optimal parameters not found. Skipping arc {(pnt_i_idx, pnt_j_idx)}")
+        logger.warning(f"Encountered error: {e}")
 
         # Fill everything with nans
         ts_length = len(Btemporal)
@@ -920,31 +923,26 @@ def arc_estimation_xarray_input(
         # Step 6. Printing
 
         if print_output:
-            print(
-                "Estimated cross_range (phase domain NMAD):",
-                np.around(x_hat_arc_ph[0, 0], 2),
-                "+/-",
-                np.around((np.sqrt(Qx_hat_arc_ph[0, 0])) / (-1 * m2ph), 2),
+            logger.info(
+                "Estimated cross_range (phase domain NMAD): "
+                f"{np.around(x_hat_arc_ph[0, 0], 2)} +/- "
+                f"{np.around((np.sqrt(Qx_hat_arc_ph[0, 0])) / (-1 * m2ph), 2)}"
             )
-            print(
-                "Estimated cross_range (2nd order + partitions and bounds):",
-                np.around(x_hat_2_p_b[-2], 2),
-                "+/-",
-                np.around((np.sqrt(pcov_2_p_b[-2, -2])) / (-1 * m2ph), 2),
+            logger.info(
+                "Estimated cross_range (2nd order + partitions and bounds): "
+                f"{np.around(x_hat_2_p_b[-2], 2)} +/- "
+                f"{np.around((np.sqrt(pcov_2_p_b[-2, -2])) / (-1 * m2ph), 2)}"
             )
-            print(
-                "Estimated thermal expansion (phase domain NMAD):",
-                np.around(x_hat_arc_ph[1, 0] * 1000 / m2ph, 4),
-                "+/-",
-                np.around(np.sqrt(Qx_hat_arc_ph[1, 1]) * 1000 / m2ph, 2),
+            logger.info(
+                "Estimated thermal expansion (phase domain NMAD): "
+                f"{np.around(x_hat_arc_ph[1, 0] * 1000 / m2ph, 4)} +/- "
+                f"{np.around(np.sqrt(Qx_hat_arc_ph[1, 1]) * 1000 / m2ph, 2)}"
             )
-            print(
-                "Estimated thermal expansion (2nd order + partitions and bounds):",
-                np.around(x_hat_2_p_b[-1] * 1000 / m2ph, 4),
-                np.around(np.sqrt(pcov_2_p_b[-1, -1]) * 1000 / m2ph, 2),
+            logger.info(
+                "Estimated thermal expansion (2nd order + partitions and bounds): "
+                f"{np.around(x_hat_2_p_b[-1] * 1000 / m2ph, 4)} "
+                f"{np.around(np.sqrt(pcov_2_p_b[-1, -1]) * 1000 / m2ph, 2)}"
             )
-            print("")
-            print("")
 
     if test_stochastics:
         return results, stochastic_results
@@ -1113,8 +1111,8 @@ def arc_estimation_control_network(
     for a in arcs_to_analyse:
         pnt_i_idx, pnt_j_idx = a
 
-        print(f"idx pnt i: {pnt_i_idx}")
-        print(f"idx pnt j: {pnt_j_idx}")
+        logger.debug(f"idx pnt i: {pnt_i_idx}")
+        logger.debug(f"idx pnt j: {pnt_j_idx}")
 
         # Extract information of the two points of the arc
         sd_complex_i = sd_complex[pnt_i_idx, :]
@@ -1280,7 +1278,7 @@ def arc_estimation_control_network(
                 bkps, xx_data, arc_obs, x0_2_p, bounds_2_p, Q_dd_cmplx, n_max_iter
             )
         except (RuntimeError, ValueError):
-            print(f"Optimal parameters not found. Skipping arc {(pnt_i_idx, pnt_j_idx)}")
+            logger.warning(f"Optimal parameters not found. Skipping arc {(pnt_i_idx, pnt_j_idx)}")
 
             # Fill everything with nans
             ts_length = len(ampl_i)
@@ -1366,31 +1364,26 @@ def arc_estimation_control_network(
                 # stochastic_results = flatten_arrays_in_dict(stochastic_results)
 
             if print_output:
-                print(
-                    "Estimated cross_range (phase domain NMAD):",
-                    np.around(x_hat_arc_ph[0, 0], 2),
-                    "+/-",
-                    np.around((np.sqrt(Q_x_hat_arc_ph[0, 0])) / (-1 * m2ph), 2),
+                logger.info(
+                    "Estimated cross_range (phase domain NMAD): "
+                    f"{np.around(x_hat_arc_ph[0, 0], 2)} +/- "
+                    f"{np.around((np.sqrt(Q_x_hat_arc_ph[0, 0])) / (-1 * m2ph), 2)}"
                 )
-                print(
-                    "Estimated cross_range (2nd order + partitions and bounds):",
-                    np.around(x_hat_2_p_b[-2], 2),
-                    "+/-",
-                    np.around((np.sqrt(pcov_2_p_b[-2, -2])) / (-1 * m2ph), 2),
+                logger.info(
+                    "Estimated cross_range (2nd order + partitions and bounds): "
+                    f"{np.around(x_hat_2_p_b[-2], 2)} +/- "
+                    f"{np.around((np.sqrt(pcov_2_p_b[-2, -2])) / (-1 * m2ph), 2)}"
                 )
-                print(
-                    "Estimated thermal expansion (phase domain NMAD):",
-                    np.around(x_hat_arc_ph[1, 0] * 1000 / m2ph, 4),
-                    "+/-",
-                    np.around(np.sqrt(Q_x_hat_arc_ph[1, 1]) * 1000 / m2ph, 2),
+                logger.info(
+                    "Estimated thermal expansion (phase domain NMAD): "
+                    f"{np.around(x_hat_arc_ph[1, 0] * 1000 / m2ph, 4)} +/- "
+                    f"{np.around(np.sqrt(Q_x_hat_arc_ph[1, 1]) * 1000 / m2ph, 2)}"
                 )
-                print(
-                    "Estimated thermal expansion (2nd order + partitions and bounds):",
-                    np.around(x_hat_2_p_b[-1] * 1000 / m2ph, 4),
-                    np.around(np.sqrt(pcov_2_p_b[-1, -1]) * 1000 / m2ph, 2),
+                logger.info(
+                    "Estimated thermal expansion (2nd order + partitions and bounds): "
+                    f"{np.around(x_hat_2_p_b[-1] * 1000 / m2ph, 4)} "
+                    f"{np.around(np.sqrt(pcov_2_p_b[-1, -1]) * 1000 / m2ph, 2)}"
                 )
-                print("")
-                print("")
 
         p = p + 1
 

--- a/depsi/network.py
+++ b/depsi/network.py
@@ -1286,7 +1286,7 @@ def construct_control_network(
         arcs_to_test = arcs_without_excluded[0:end_idx]
 
         if not arcs_to_test:  # Break if no more arcs to add
-            print("No more arcs to test.")
+            logger.info("No more arcs to test.")
             more_arcs_to_test = False
             continue
 
@@ -1305,7 +1305,7 @@ def construct_control_network(
 
         # Test the network against requirements
         avg_degree = len(current_network.edges) / len(current_network.nodes) if len(current_network.nodes) > 0 else 0
-        print(f"The average degree is {avg_degree:.2f}")
+        logger.debug(f"The average degree is {avg_degree:.2f}")
 
         if len(current_network.nodes) >= min_nodes and avg_degree >= min_redundancy:
             network_reqs_not_met = False
@@ -1313,7 +1313,7 @@ def construct_control_network(
 
     # Final check if the network meets requirements
     if len(current_network.nodes) < min_nodes or avg_degree < min_redundancy:
-        print("Warning: Network could not meet all requirements with the given arcs.")
+        logger.warning("Network could not meet all requirements with the given arcs.")
 
     # The arcs constructed above are no longer sorted based on their quality
     arcs_updated_network_sorted = sorted(
@@ -1516,7 +1516,7 @@ def test_succeeded_arcs_control_network(
     if not nodes_to_remove:
         # Test the network against requirements
         avg_degree = len(current_network.edges) / len(current_network.nodes) if len(current_network.nodes) > 0 else 0
-        print(f"The average degree is {avg_degree:.2f}")
+        logger.debug(f"The average degree is {avg_degree:.2f}")
 
         if len(current_network.nodes) >= min_nodes and avg_degree >= min_redundancy:
             network_check = 1
@@ -1527,7 +1527,7 @@ def test_succeeded_arcs_control_network(
             )
 
     else:
-        print("We remove low degree nodes")
+        logger.debug("We remove low degree nodes")
         # Remove the nodes with low degree and test the network again
         current_network, _, ref_pnt = _remove_low_centrality_nodes(
             current_network, deg_threshold=deg_threshold, plot=visualize_network
@@ -1536,7 +1536,7 @@ def test_succeeded_arcs_control_network(
 
         # Test the network against requirements
         avg_degree = len(current_network.edges) / len(current_network.nodes) if len(current_network.nodes) > 0 else 0
-        print(f"The average degree is {avg_degree:.2f}")
+        logger.debug(f"The average degree is {avg_degree:.2f}")
 
         if len(current_network.nodes) >= min_nodes and avg_degree >= min_redundancy:
             network_check = 1
@@ -1784,7 +1784,7 @@ def construct_control_network_test_arcs(
             False,
         )
 
-        print("Computing the solutions for the arcs")
+        logger.info("Computing the solutions for the arcs")
         # Test whether solutions for all arcs can be found (sometimes it happens that because of the complex
         # functions no solutions can be found)
         results_initial_control_network_v1 = arc_estimation_control_network(
@@ -1826,7 +1826,7 @@ def construct_control_network_test_arcs(
             if np.isnan(succeeded).any() or not succeeded.any()
         ]
         failed_arcs = list(set(failed_arcs).union(failed_arcs_temp))
-        print(f"Failed arcs {failed_arcs}")
+        logger.info(f"Failed arcs {failed_arcs}")
 
         # Remove the failed arcs from the dictionary with all the results (as the estimated parameters etc)
         results_initial_control_network_v2 = {}  # Make a new dictionary where we will not save
@@ -1846,7 +1846,7 @@ def construct_control_network_test_arcs(
             else:
                 results_initial_control_network_v2[key] = value  # Keep values that are not row-based unchanged
 
-        print("Check if the network with the solved arcs still meets our requirements")
+        logger.info("Check if the network with the solved arcs still meets our requirements")
 
         # Since we have 'failed_arcs', where no solution was found, the new network need to be tested
         # It can happen that we have isolated points,
@@ -1856,10 +1856,10 @@ def construct_control_network_test_arcs(
         )
 
         if network_check == 0:
-            print("Network fails requirements, starting again")
+            logger.warning("Network fails requirements, starting again")
 
         if network_check == 1:
-            print("Network meets requirements")
+            logger.info("Network meets requirements")
             # After the last test, the isolated arcs are removed (so they are still in
             # 'succeeded_arcs' and in the dictionary)
             # And these arcs need to be removed from the dictionary
@@ -1882,7 +1882,7 @@ def construct_control_network_test_arcs(
             # We compute solutions for all arcs and computed RMSE
             # In the next part, we will remove any arcs that are too noisy for the requirements, and then test if
             # the network still fulfills the requirements
-            print("Calculate whether there are arcs where the solution that we found is noisy")
+            logger.info("Calculate whether there are arcs where the solution that we found is noisy")
 
             est_displ_phase = (
                 results_control_network_temp["unwrap_phases_arc"]
@@ -1902,30 +1902,28 @@ def construct_control_network_test_arcs(
             good_arcs = results_control_network_temp["succeeded_arcs"][idx_good_arcs].astype(int)
             good_arcs = [tuple(row) for row in good_arcs]  # Change the output to a list
 
-            print(f"The value for sigma_post_over_prior is {sigma_post_over_sigma_prior}")
+            logger.debug(f"The value for sigma_post_over_prior is {sigma_post_over_sigma_prior}")
 
-            print("we removed arcs")
+            logger.debug("we removed arcs")
 
-            print("The bad arcs are")
-            print(idx_bad_arcs)
-            print("The good arcs are")
-            print(idx_good_arcs)
+            logger.debug(f"The bad arcs are: {idx_bad_arcs}")
+            logger.debug(f"The good arcs are: {idx_good_arcs}")
 
             # Add the noisy arcs to the list with failed_arcs
             failed_arcs = list(set(failed_arcs).union([tuple(row.astype(int)) for row in bad_arcs]))
             noisy_arcs = list(set(noisy_arcs).union([tuple(row.astype(int)) for row in bad_arcs]))
 
             # Check whether the network without the noisy arcs still meets requirements
-            print("Check whether the network stil meets the requirements, even after the removal of bad arcs")
+            logger.info("Check whether the network stil meets the requirements, even after the removal of bad arcs")
             network_check_good, arcs_updated_network, ref_pnt = test_succeeded_arcs_control_network(
                 good_arcs, quality_dict_arcs, deg_threshold, min_nodes, min_redundancy, visualize_network=False
             )
 
             if network_check_good == 0:
-                print("Network does not meet requirements, start over")
+                logger.warning("Network does not meet requirements, start over")
 
             if network_check_good == 1:
-                print("We are happy! The network consisting of the good arcs fulfills the requirements.")
+                logger.info("We are happy! The network consisting of the good arcs fulfills the requirements.")
 
                 # If there are noisy arcs, they need to be removed from the final network
                 # Convert noisy_arcs to set for quicker lookup
@@ -1950,7 +1948,9 @@ def construct_control_network_test_arcs(
 
         if not network_meets_requirements:
             # If the network doesn't meet the requirements, start over
-            print("Network does not meet the requirements. Recomputing the network with updated failed_arcs...")
+            logger.warning(
+                "Network does not meet the requirements. Recomputing the network with updated failed_arcs..."
+            )
 
     return results_control_network, ref_pnt, arcs_updated_network
 


### PR DESCRIPTION
Fixes #101.

`network.py` already sets up a module logger (`logger = logging.getLogger(__name__)`), but most of its diagnostic output still went through `print()`. `arc_estimation.py` had no logger at all. This replaces every `print()` in both modules with the appropriate `logger` call, so output can actually be captured/filtered in sbatch/HPC environments as the issue asks for:

- Narrative progress markers (e.g. "Computing the solutions for the arcs") → `logger.info`, staying visible under the `INFO` level the processing scripts already configure by default (`script_depsi_processing.py`, `script_reslc.py`).
- Per-iteration/per-arc diagnostics (average degree each loop pass, per-arc point indices) → `logger.debug`, since these fire many times and were previously always-on noise.
- Failure/retry conditions (network not meeting requirements, an arc's optimal parameters not found) → `logger.warning`.

Also collapsed a few adjacent label/value `print()` pairs into single f-string `logger.debug` calls, and removed two now-redundant blank `print("")` separators.

**Note on scope**: the issue also names a third module, `network_adjustment` — no such module exists anywhere in this repo's history (checked `git log --all`); the network-adjustment logic already lives in `network.py`, which this PR covers.

**Testing**: verified with `ruff check` and `ruff format --check` (both clean) and a syntax compile of both files. I wasn't able to run the full test suite locally due to disk space constraints on my end, but no control flow was touched in either file — only the `print` → `logger` substitution, which is behavior-preserving beyond output destination/level.