### PR TITLE
Set up version-based documentation with mike

### DIFF
--- a/.github/workflows/doc_deploy.yml
+++ b/.github/workflows/doc_deploy.yml
@@ -17,12 +17,26 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages --depth=1
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install dependencies
         run: |
-          python -m pip install .[docs] 
-      - name: Deploy docs
-        run: mkdocs gh-deploy --force
+          python -m pip install .[docs]
+      - name: Configure git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Determine docs version
+        id: docs_version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION=$(echo "$TAG" | sed -E 's/^v?([0-9]+\.[0-9]+).*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Deploy versioned docs
+        run: |
+          mike deploy --push --update-aliases ${{ steps.docs_version.outputs.version }} latest
+          mike set-default --push latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,16 @@ classifiers=[
     'Programming Language :: Python :: 3.12',
 ]
 
+[project.optional-dependencies]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocs-jupyter",
+    "mkdocstrings[python]",
+    "mkdocs-gen-files",
+    "mike",
+]
+
 [dependency-groups]
 dev = [
     "pytest",
@@ -53,6 +63,7 @@ docs = [
     "mkdocs-jupyter",
     "mkdocstrings[python]",
     "mkdocs-gen-files",
+    "mike",
 ]
 demo = [
     "jupyterlab",


### PR DESCRIPTION
Fixes #122.

`mkdocs.yml` already declared `extra.version.provider: mike` (which enables the mkdocs-material version selector), but nothing actually deployed versioned docs: `mike` wasn't installed anywhere, and the release workflow ran a plain `mkdocs gh-deploy --force`, which overwrites the whole `gh-pages` branch with a single, unversioned build every release.

**What this does:**
- Adds `mike` to the docs dependencies.
- Replaces the `gh-deploy` step with `mike deploy --push --update-aliases <major.minor> latest` followed by `mike set-default --push latest`, deriving `<major.minor>` from the release tag (`v0.1.2` → `0.1`). One doc set per minor version, aliased to `latest` for the newest.
- Configures the git identity `mike` needs to commit to `gh-pages`, and explicitly fetches the `gh-pages` branch first (a checkout of the triggering ref doesn't include other branches — `mike`'s own docs flag this as a common CI gotcha).

**Also fixes a pre-existing, unrelated break in the same workflow**: `pip install .[docs]` needs a `[project.optional-dependencies]` table, but `docs` was only defined under `[dependency-groups]` (PEP 735, likely for local `uv` use). That mismatch meant the deploy job's install step silently installed *no* docs dependencies — not even `mkdocs` itself. Added the matching `[project.optional-dependencies]` table so `.[docs]` actually resolves; left the `[dependency-groups]` entry as-is for any `uv`-based local dev flow.

**Testing:** validated `pyproject.toml` (TOML parse) and `doc_deploy.yml` (YAML parse + ruff clean on the repo). This workflow only runs on `release: published`, so it can't be exercised in CI on the PR itself — happy to walk through the exact `mike` commands with a maintainer if useful.