### PR TITLE
Add depsi.visualization module for plotting point and arc STMs

### DIFF
--- a/depsi/__init__.py
+++ b/depsi/__init__.py
@@ -8,6 +8,7 @@ from depsi.network import (
     form_network,
     spatial_integration,
 )
+from depsi.visualization import plot_arcs, plot_mrm, plot_points
 
 __all__ = (
     "read_slc_stack",
@@ -19,4 +20,7 @@ __all__ = (
     "densification",
     "estimate_model_params",
     "estimate_atmosphere_phase",
+    "plot_mrm",
+    "plot_points",
+    "plot_arcs",
 )

--- a/depsi/visualization.py
+++ b/depsi/visualization.py
@@ -1,0 +1,214 @@
+"""Visualization utilities for point and arc STMs.
+
+These functions replace the plotting boilerplate repeated across the example notebooks: drawing a Mean
+Reflectivity Map (MRM) as a radar-coordinate basemap, then overlaying point STMs (as a scatter, optionally
+coloured by a data variable) or arc STMs (as line segments between their source/target points, optionally
+coloured by a data variable) on top of it.
+
+All three functions plot in radar coordinates (`range`/`azimuth` by default), matching the coordinate system
+of the MRM raster - not `lat`/`lon`, which does not align with the MRM's pixel grid.
+"""
+
+from typing import Literal
+
+import matplotlib.colors as plc
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from matplotlib.axes import Axes
+
+
+def plot_mrm(
+    mrm: xr.DataArray,
+    ax: Axes | None = None,
+    clim: tuple[float, float] = (0, 40000),
+    cmap: str = "gray",
+    aspect: float | Literal["auto", "equal"] | None = None,
+) -> Axes:
+    """Plot a Mean Reflectivity Map (MRM) as a radar-coordinate basemap.
+
+    Parameters
+    ----------
+    mrm: xarray.DataArray
+        Mean Reflectivity Map, e.g. as returned by `stack.slcstack.mrm()`. If it is a lazy (dask-backed)
+        array, it is computed before plotting.
+    ax: matplotlib.axes.Axes, optional
+        Axes to plot on. A new figure and axes are created if not given.
+    clim: tuple of float
+        Colour limits passed to the MRM image, as (vmin, vmax). Default is (0, 40000).
+    cmap: str
+        Colormap for the MRM image. Default is "gray".
+    aspect: float, "auto", "equal", or None
+        Axes aspect ratio, forwarded to `ax.set_aspect`. Left as the matplotlib default (None) unless given:
+        the range/azimuth pixel spacing ratio is product-specific, so there is no universally correct default.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes the MRM was plotted on.
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    if getattr(mrm, "chunks", None) is not None:
+        mrm = mrm.compute()
+
+    im = mrm.plot(ax=ax, cmap=cmap, add_colorbar=False)
+    im.set_clim(clim)
+
+    if aspect is not None:
+        ax.set_aspect(aspect)
+    ax.axis("off")
+
+    return ax
+
+
+def plot_points(
+    stm_points: xr.Dataset,
+    mrm: xr.DataArray | None = None,
+    color_by: str | None = None,
+    ax: Axes | None = None,
+    cmap: str = "jet_r",
+    colorbar: bool = True,
+    x_coord: str = "range",
+    y_coord: str = "azimuth",
+    mrm_kwargs: dict | None = None,
+    **scatter_kwargs,
+) -> Axes:
+    """Plot a point STM as a scatter, optionally over an MRM basemap.
+
+    Parameters
+    ----------
+    stm_points: xarray.Dataset
+        Point STM with a `space` dimension, and `x_coord`/`y_coord` (default `range`/`azimuth`) coordinates
+        or data variables on that dimension.
+    mrm: xarray.DataArray, optional
+        Mean Reflectivity Map to draw as a basemap before the scatter, via `plot_mrm`.
+    color_by: str, optional
+        Name of a data variable on `stm_points` to colour the points by. If not given, `scatter_kwargs["c"]`
+        is used if present, otherwise all points are drawn in a single default colour.
+    ax: matplotlib.axes.Axes, optional
+        Axes to plot on. A new figure and axes are created if not given.
+    cmap: str
+        Colormap used when `color_by` is given. Default is "jet_r".
+    colorbar: bool
+        Whether to add a colorbar when `color_by` is given. Default is True.
+    x_coord, y_coord: str
+        Names of the coordinates/data variables on `stm_points` to use for the point positions.
+        Default is "range" and "azimuth".
+    mrm_kwargs: dict, optional
+        Extra keyword arguments forwarded to `plot_mrm` when `mrm` is given.
+    **scatter_kwargs
+        Extra keyword arguments forwarded to `ax.scatter` (e.g. `s`, `marker`, `vmin`, `vmax`, `norm`).
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes the points were plotted on.
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    if mrm is not None:
+        plot_mrm(mrm, ax=ax, **(mrm_kwargs or {}))
+
+    if color_by is not None:
+        scatter_kwargs["c"] = stm_points[color_by].values
+        scatter_kwargs.setdefault("cmap", cmap)
+
+    scatter = ax.scatter(stm_points[x_coord].values, stm_points[y_coord].values, **scatter_kwargs)
+
+    if color_by is not None and colorbar:
+        plt.colorbar(scatter, ax=ax, label=color_by)
+
+    return ax
+
+
+def plot_arcs(
+    stm_points: xr.Dataset,
+    stm_arcs: xr.Dataset,
+    mrm: xr.DataArray | None = None,
+    color_by: str | None = None,
+    ax: Axes | None = None,
+    cmap: str = "jet_r",
+    vmin: float | None = None,
+    vmax: float | None = None,
+    colorbar: bool = True,
+    linewidth: float = 0.5,
+    default_color: str = "tab:blue",
+    x_coord: str = "range",
+    y_coord: str = "azimuth",
+    mrm_kwargs: dict | None = None,
+) -> Axes:
+    """Plot arc STMs as line segments between their source and target points, optionally over an MRM basemap.
+
+    Parameters
+    ----------
+    stm_points: xarray.Dataset
+        Point STM the arcs' `source`/`target` indices refer to, with `x_coord`/`y_coord` (default
+        `range`/`azimuth`) coordinates or data variables on its `space` dimension.
+    stm_arcs: xarray.Dataset
+        Arc STM with a `space` dimension, and `source`/`target` data variables holding integer positional
+        indices into `stm_points`'s `space` dimension.
+    mrm: xarray.DataArray, optional
+        Mean Reflectivity Map to draw as a basemap before the arcs, via `plot_mrm`.
+    color_by: str, optional
+        Name of a data variable on `stm_arcs` to colour the arcs by (its absolute value is used, e.g. for a
+        complex-valued temporal coherence). If not given, all arcs are drawn in `default_color`.
+    ax: matplotlib.axes.Axes, optional
+        Axes to plot on. A new figure and axes are created if not given.
+    cmap: str
+        Colormap used when `color_by` is given. Default is "jet_r".
+    vmin, vmax: float, optional
+        Colour scale limits used when `color_by` is given. Default to the data's own min/max.
+    colorbar: bool
+        Whether to add a colorbar when `color_by` is given. Default is True.
+    linewidth: float
+        Line width for the arcs. Default is 0.5.
+    default_color: str
+        Colour used for all arcs when `color_by` is not given. Default is "tab:blue".
+    x_coord, y_coord: str
+        Names of the coordinates/data variables on `stm_points` to use for the arc endpoint positions.
+        Default is "range" and "azimuth".
+    mrm_kwargs: dict, optional
+        Extra keyword arguments forwarded to `plot_mrm` when `mrm` is given.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes the arcs were plotted on.
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    if mrm is not None:
+        plot_mrm(mrm, ax=ax, **(mrm_kwargs or {}))
+
+    source = stm_arcs["source"].values
+    target = stm_arcs["target"].values
+    n_arcs = stm_arcs.sizes["space"]
+
+    xx = np.stack([stm_points[x_coord].values[source], stm_points[x_coord].values[target]]).T
+    yy = np.stack([stm_points[y_coord].values[source], stm_points[y_coord].values[target]]).T
+
+    norm = None
+    if color_by is not None:
+        values = np.abs(stm_arcs[color_by].values)
+        norm = plc.Normalize(
+            vmin=vmin if vmin is not None else values.min(),
+            vmax=vmax if vmax is not None else values.max(),
+        )
+        cmap_obj = plt.get_cmap(cmap)
+        colors = cmap_obj(norm(values))
+    else:
+        colors = [default_color] * n_arcs
+
+    for i in range(n_arcs):
+        ax.plot(xx[i], yy[i], color=colors[i], linewidth=linewidth)
+
+    if color_by is not None and colorbar:
+        sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
+        sm.set_array([])
+        plt.colorbar(sm, ax=ax, label=color_by)
+
+    return ax

--- a/docs/api/visualization.md
+++ b/docs/api/visualization.md
@@ -1,0 +1,14 @@
+::: depsi.visualization.plot_mrm
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: depsi.visualization.plot_points
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: depsi.visualization.plot_arcs
+    options:
+      show_root_heading: true
+      show_source: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - depsi.contextual_information: api/contextual_information.md
     - depsi.transformations: api/transformations.md
     - depsi.io: api/io.md
+    - depsi.visualization: api/visualization.md
   - Contributing: 
     - Contributing guide: CONTRIBUTING.md
     - Practical info for developers: dev_guide.md

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,143 @@
+import dask.array as da
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
+from matplotlib.collections import PathCollection, QuadMesh
+
+from depsi.visualization import plot_arcs, plot_mrm, plot_points
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def mrm():
+    # Real MRM DataArrays carry evenly-spaced range/azimuth coordinates, which is what makes
+    # xarray's `.plot()` render an AxesImage (imshow) rather than falling back to a QuadMesh
+    # (pcolormesh) for coordinate-less 2D data.
+    data = np.arange(20, dtype=float).reshape(4, 5)
+    return xr.DataArray(data, dims=("azimuth", "range"), coords={"azimuth": np.arange(4), "range": np.arange(5)})
+
+
+@pytest.fixture
+def stm_points():
+    return xr.Dataset(
+        data_vars={
+            "velocity": ("space", np.array([1.0, 2.0, 3.0, 4.0])),
+        },
+        coords={
+            "range": ("space", np.array([0, 1, 2, 3])),
+            "azimuth": ("space", np.array([0, 1, 2, 3])),
+        },
+    )
+
+
+@pytest.fixture
+def stm_arcs():
+    return xr.Dataset(
+        data_vars={
+            "source": ("space", np.array([0, 1, 2])),
+            "target": ("space", np.array([1, 2, 3])),
+            "temp_coh": ("space", np.array([0.9, 0.1, 0.5])),
+        },
+    )
+
+
+def test_plot_mrm_returns_axes_with_image(mrm):
+    # xarray's DataArray.plot() renders 2D data as a QuadMesh (pcolormesh), not an AxesImage.
+    ax = plot_mrm(mrm)
+    assert ax is not None
+    assert len(ax.collections) == 1
+    assert ax.collections[0].get_clim() == (0, 40000)
+
+
+def test_plot_mrm_custom_clim_and_cmap(mrm):
+    ax = plot_mrm(mrm, clim=(0, 10), cmap="viridis")
+    quadmesh = ax.collections[0]
+    assert quadmesh.get_clim() == (0, 10)
+    assert quadmesh.get_cmap().name == "viridis"
+
+
+def test_plot_mrm_computes_dask_backed_array(mrm):
+    lazy_mrm = mrm.copy()
+    lazy_mrm.data = da.from_array(mrm.data, chunks=(2, 5))
+
+    ax = plot_mrm(lazy_mrm)
+    assert len(ax.collections) == 1
+
+
+def test_plot_mrm_no_colorbar(mrm):
+    ax = plot_mrm(mrm)
+    assert len(ax.figure.axes) == 1  # no colorbar axes added
+
+
+def test_plot_points_positions(stm_points):
+    ax = plot_points(stm_points)
+    offsets = ax.collections[0].get_offsets()
+    expected = np.column_stack([stm_points["range"].values, stm_points["azimuth"].values])
+    assert np.allclose(offsets, expected)
+
+
+def test_plot_points_color_by_adds_colorbar(stm_points):
+    ax = plot_points(stm_points, color_by="velocity")
+    scatter = ax.collections[0]
+    assert np.allclose(scatter.get_array(), stm_points["velocity"].values)
+    assert len(ax.figure.axes) == 2  # scatter axes + colorbar axes
+
+
+def test_plot_points_no_color_by_no_colorbar(stm_points):
+    ax = plot_points(stm_points)
+    assert len(ax.figure.axes) == 1
+
+
+def test_plot_points_over_mrm(stm_points, mrm):
+    ax = plot_points(stm_points, mrm=mrm)
+    assert sum(isinstance(c, QuadMesh) for c in ax.collections) == 1
+    assert sum(isinstance(c, PathCollection) for c in ax.collections) == 1
+
+
+def test_plot_arcs_line_positions(stm_points, stm_arcs):
+    ax = plot_arcs(stm_points, stm_arcs)
+    assert len(ax.lines) == 3
+
+    source = stm_arcs["source"].values
+    target = stm_arcs["target"].values
+    for i, line in enumerate(ax.lines):
+        expected_x = [stm_points["range"].values[source[i]], stm_points["range"].values[target[i]]]
+        expected_y = [stm_points["azimuth"].values[source[i]], stm_points["azimuth"].values[target[i]]]
+        assert np.allclose(line.get_xdata(), expected_x)
+        assert np.allclose(line.get_ydata(), expected_y)
+
+
+def test_plot_arcs_default_color(stm_points, stm_arcs):
+    ax = plot_arcs(stm_points, stm_arcs)
+    colors = {line.get_color() for line in ax.lines}
+    assert colors == {"tab:blue"}
+    assert len(ax.figure.axes) == 1  # no colorbar without color_by
+
+
+def test_plot_arcs_color_by_adds_colorbar(stm_points, stm_arcs):
+    ax = plot_arcs(stm_points, stm_arcs, color_by="temp_coh")
+    colors = {tuple(np.atleast_1d(line.get_color())) for line in ax.lines}
+    assert len(colors) == 3  # three distinct temp_coh values -> three distinct colors
+    assert len(ax.figure.axes) == 2
+
+
+def test_plot_arcs_color_by_uses_absolute_value(stm_points, stm_arcs):
+    stm_arcs["temp_coh"] = ("space", np.array([-0.9, 0.1, 0.5]))
+    ax_negative = plot_arcs(stm_points, stm_arcs, color_by="temp_coh", vmin=0, vmax=1)
+
+    stm_arcs["temp_coh"] = ("space", np.array([0.9, 0.1, 0.5]))
+    ax_positive = plot_arcs(stm_points, stm_arcs, color_by="temp_coh", vmin=0, vmax=1)
+
+    assert np.array_equal(ax_negative.lines[0].get_color(), ax_positive.lines[0].get_color())
+
+
+def test_plot_arcs_over_mrm(stm_points, stm_arcs, mrm):
+    ax = plot_arcs(stm_points, stm_arcs, mrm=mrm)
+    assert sum(isinstance(c, QuadMesh) for c in ax.collections) == 1
+    assert len(ax.lines) == 3


### PR DESCRIPTION
Fixes #86.

Every notebook that plots a point or arc STM over the MRM basemap repeats the same ~10-15 lines: compute the (often dask-backed) MRM, imshow/plot it with a fixed color limit, strip its colorbar and axes, then scatter points or loop-plot arc line segments colored by a data variable — e.g. `demo_depsi_full.ipynb` cells 7/10/13/16/19/23, and `demo_network.ipynb`'s network-arc example (also the example given in the issue).

**Adds three functions**, all operating in radar coordinates (`range`/`azimuth`, matching the MRM's own pixel grid rather than lat/lon) and returning the `Axes` for composability:
- `plot_mrm` — the basemap: computes a dask-backed MRM if needed, plots with a given color limit/cmap, strips ticks/spines. Aspect ratio is left to the caller (the `2` used in the notebooks is specific to that product's pixel spacing, not universal).
- `plot_points` — scatter a point STM, optionally over an MRM basemap, optionally colored by a data variable with a colorbar.
- `plot_arcs` — draw each arc as a line between its source/target points, optionally over an MRM basemap, optionally colored by an arc data variable (absolute value, for complex-valued temporal coherence).

Wired into `depsi/__init__.py` and the mkdocs API reference the same way every other module is.

**Testing**: synthetic point/arc STM and MRM fixtures, checking the resulting `Axes`' children directly (scatter offsets/colors, line endpoints/colors, colorbar presence, MRM color limits, dask computation). Ran the full suite locally: 232 passed (219 existing + 13 new), plus `mkdocs build --strict`, `ruff check`, and `ruff format --check` — all clean.